### PR TITLE
Wrap lines at 120 characters

### DIFF
--- a/src/clip_utils/clip_encoder.py
+++ b/src/clip_utils/clip_encoder.py
@@ -11,9 +11,11 @@ def load_clip_model(model_name="ViT-B/32",
         Tuple[ClipModel, Compose]:
     """Loads a CLIP model, together with its associated preprocessing steps.
 
-    :param model_name: The name of the CLIP model to load. See clip.available_models() for a complete list of available models.
+    :param model_name: The name of the CLIP model to load. See clip.available_models() for a complete list of available
+                       models.
     :param device: The device (cpu, cuda, ...) on which the operations take place.
-    :return: A tuple containing the loaded CLIP model and the associated Compose transform to apply to the images input to the image encoder.
+    :return: A tuple containing the loaded CLIP model and the associated Compose transform to apply to the images input
+             to the image encoder.
     """
 
     model, preprocess = clip.load(model_name, device=device)


### PR DESCRIPTION
120 characters should be a good compromise between support for older monitors, looking at code in console, or even looking at code with side-by-side comparison, and a line length that does not need to be cut all of the time.